### PR TITLE
Codeclimate fix keras test

### DIFF
--- a/docs/reference/api/keras.txt
+++ b/docs/reference/api/keras.txt
@@ -118,11 +118,26 @@ Callbacks
 =========
 
 To execute arbitrary Python code during the lifecycle of a
-``TFKerasTrial``, implement the standard Keras callback interface
-``tf.keras.callbacks.Callbacks`` and supply them to the ``TFKerasTrial``
-by implementing :meth:`~determined.keras.TFKerasTrial.keras_callbacks`.
+``TFKerasTrial``, implement the
+:class:`determined.keras.callbacks.Callback` interface (an extension of
+the ``tf.keras.callbacks.Callbacks`` interface) and supply them to the
+``TFKerasTrial`` by implementing
+:meth:`~determined.keras.TFKerasTrial.keras_callbacks`.
 
 .. autofunction:: determined.keras.TFKerasTrial.keras_callbacks
+
+********************************
+ ``determined.keras.callbacks``
+********************************
+
+.. autoclass:: determined.keras.callbacks.Callback
+   :members:
+
+.. autoclass:: determined.keras.callbacks.DeterminedProgress
+
+.. autoclass:: determined.keras.callbacks.EarlyStopping
+
+.. autoclass:: determined.keras.callbacks.ReduceLROnPlateau
 
 **********
  Examples

--- a/docs/release-notes/1458-fix-keras-callbacks.rst
+++ b/docs/release-notes/1458-fix-keras-callbacks.rst
@@ -1,0 +1,25 @@
+:orphan:
+
+**Fixes**
+
+- Fix support for Keras Callbacks.
+
+  - Previously, stateful Keras Callbacks (``EarlyStopping`` and
+    ``ReduceLROnPlateau``) did not work in Determined across pause/activate
+    boundaries.  We have introduced Determined-friendly implementations,
+    :class:`determined.keras.callbacks.EarlyStopping` and
+    :class:`determined.keras.callbacks.ReduceLROnPlateau`, which address this
+    shortcoming.  User-defined callbacks may subclass
+    :class:`determined.keras.callbacks.Callback` (and define ``get_state`` and
+    ``load_state`` methods) to also benfit from this and other new features.
+
+  - Previously, Keras Callbacks which relied on ``on_epoch_end`` in Determined
+    would see their ``on_epoch_end`` called every ``scheduling_unit`` batches
+    by default.  Now, ``on_epoch_end`` will be reliably called at the end of
+    each epoch, as defined by the ``records_per_epoch`` setting in the
+    experiment config.  As before, ``on_epoch_end`` will not contain validation
+    metrics, as the validation data is not always fresh at epoch boundaries.
+    Therefore, the Determined implementations of
+    :class:`~determined.keras.callbacks.EarlyStopping` and
+    :class:`~determined.keras.callbacks.ReduceLROnPlateau` are both based on
+    ``on_test_end``, which can be tuned using ``min_validation_period``.

--- a/harness/determined/_experiment_config.py
+++ b/harness/determined/_experiment_config.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import Dict, List, Optional, cast
 
 
 class ExperimentConfig(dict):
@@ -32,3 +32,12 @@ class ExperimentConfig(dict):
 
     def get_data_layer_type(self) -> str:
         return cast(str, self["data_layer"]["type"])
+
+    def get_records_per_epoch(self) -> Optional[int]:
+        records_per_epoch = self.get("records_per_epoch")
+        return int(records_per_epoch) if records_per_epoch is not None else None
+
+    def get_min_validation_period(self) -> Dict:
+        min_validation_period = self.get("min_validation_period", {})
+        assert isinstance(min_validation_period, dict)
+        return min_validation_period

--- a/harness/determined/keras/__init__.py
+++ b/harness/determined/keras/__init__.py
@@ -1,3 +1,4 @@
+from determined.keras import callbacks
 from determined.keras._data import (
     _ArrayLikeAdapter,
     _adapt_keras_data,

--- a/harness/determined/keras/callbacks.py
+++ b/harness/determined/keras/callbacks.py
@@ -1,0 +1,637 @@
+from typing import Any, Dict, List, Optional
+
+import tensorflow as tf
+from packaging import version
+from tensorflow.python.keras.utils import tf_utils
+
+
+class Callback(tf.keras.callbacks.Callback):  # type: ignore
+    """
+    A Determined subclass of the ``tf.keras.callbacks.Callback`` interface which supports
+    additional new callbacks.
+
+    .. warning::
+
+       The following behaviors differ between normal Keras operation and Keras
+       operation within Determined:
+
+        * Keras calls on_epoch_end at the end of the training dataset, but Determined calls it
+          based on the records_per_epoch setting in the experiment config.
+
+        * Keras calls on_epoch_end with training and validation logs, but Determined does not
+          schedule training or validation around epochs in general, so Determined cannot
+          guarantee that those values are available for on_epoch_end calls.  As a result,
+          on_epoch_end will be called with an empty dictionary for its logs.
+
+        * Keras does not support stateful callbacks, but Determined does.  Therefore:
+
+           * The tf.keras version of ``EarlyStopping`` will not work right in Determined.  You
+             should use you should use :class:`determined.keras.callbacks.EarlyStopping` instead.
+           * The tf.keras version of ``ReduceLROnPlateau`` will not work right in Determined.  You
+             should use you should use :class:`determined.keras.callbacks.ReduceLRScheduler`
+             instead.
+
+          The Determined versions are based around ``on_test_end`` rather than ``on_epoch_end``,
+          which can be influenced by setting ``min_validation_period`` in the experiment
+          configuration.
+    """
+
+    def on_train_workload_begin(
+        self, total_batches_trained: int, batches_requested: Optional[int], logs: Dict
+    ) -> None:
+        """
+        on_train_workload_begin is called before a chunk of model training.  The number of batches
+        in the workload may vary, but will not exceed the scheduling_unit setting for the
+        experiment.
+
+        Parameters:
+            total_batches_trained:  The number of batches trained at the start of the workload.
+
+            batches_requested: The number of batches expected to train during the workload.
+
+            logs: a dictionary (presently always an empty dictionary)
+        """
+        pass
+
+    def on_train_workload_end(self, total_batches_trained: int, logs: Dict) -> None:
+        """
+        on_train_workload_end is called after a chunk of model training.
+
+        Parameters:
+            total_batches_trained:  The number of batches trained at the end of the workload.
+
+            logs: a dictionary of training metrics aggregated during this workload.
+        """
+        pass
+
+    def on_checkpoint_end(self, checkpoint_dir: str) -> None:
+        """
+        on_checkpoint_end is called after a checkpoint is finished, and allows users to save
+        arbitrary files alongside the checkpoint.
+
+        Parameters:
+            checkpoint_dir:  The path to the checkpoint_dir where new files may be added.
+        """
+        pass
+
+    def get_state(self) -> Any:
+        """
+        get_state should return a pickleable object that represents the state of this callback.
+
+        When training is continued from a checkpoint, the value returned from get_state() will be
+        passed back to the Callback object via load_state().
+        """
+        return None
+
+    def load_state(self, state: Any) -> None:
+        """
+        load_state should accept the exact pickleable object returned by get_state to restore the
+        internal state of a stateful Callback as it was when load_state was called.
+        """
+        pass
+
+
+class _PolyLogs:
+    """Support the tf2.3+ feature of passing numpy or tf logs to each callback."""
+
+    def __init__(self, tf_logs: Optional[Dict]) -> None:
+        self.tf_logs = tf_logs or {}
+        self.np_logs = None  # type: Optional[Dict]
+
+    if version.parse(tf.__version__) < version.parse("2.3.0"):
+
+        def __call__(self, supports_tf_logs: bool) -> Dict:
+            return self.tf_logs
+
+    else:
+
+        def __call__(self, supports_tf_logs: bool) -> Dict:
+            if supports_tf_logs:
+                return self.tf_logs
+            if self.np_logs is None:
+                self.np_logs = tf_utils.to_numpy_or_python_type(self.tf_logs)
+            return self.np_logs
+
+
+class _MultiplexerBase(tf.keras.callbacks.Callback):  # type: ignore
+    """
+    _MultiplexerBase injects the calls so that Determined Callbacks work inside of Keras.
+
+    _MultiplexerBase is capable of injecting certain calls, such as on_epoch_end, on its own, based
+    purely on counting batches that pass through it.  However, it cannot trigger
+    on_train_workload_end on it's own, as the source of truth for that call when training on the
+    cluster is the determined-master.
+
+    Therefore, _MultiplexerBase is a private object that is not useful on its own.  It is
+    subclassed for either local training mode or cluster training mode.
+    """
+
+    _chief_worker_only = False
+    _supports_tf_logs = True
+
+    class SavableState:
+        """SavableState makes it easy to persist state using vars(self.state)."""
+
+        def __init__(
+            self,
+            epoch: int,
+            want_epoch_begin: bool,
+            epoch_batches: int,
+            latest_training_metrics: Dict,
+            total_batches: int,
+        ) -> None:
+            self.epoch = epoch
+            self.want_epoch_begin = want_epoch_begin
+            self.epoch_batches = epoch_batches
+            self.latest_training_metrics = latest_training_metrics
+            self.total_batches = total_batches
+
+    def __init__(
+        self,
+        callbacks: List[Callback],
+        is_chief: bool,
+        batch_size: int,
+        batches_per_epoch: Optional[None],
+        load_state: Optional[Dict],
+    ) -> None:
+        self.all_callbacks = callbacks
+        self.callbacks = [cb for cb in callbacks if is_chief or not cb._chief_worker_only]
+        self.is_chief = is_chief
+        self.batch_size = batch_size
+        self.batches_per_epoch = batches_per_epoch
+        self.load_state = load_state
+
+        # batches_requested requested (for on_train_workload_begin) must be passed in from outside.
+        self.batches_requested = None  # type: Optional[int]
+
+        self.want_train_workload_begin = True
+
+        self.state = self.SavableState(
+            epoch=0,
+            want_epoch_begin=True,
+            epoch_batches=0,
+            latest_training_metrics={},
+            total_batches=0,
+        )
+
+    def set_params(self, params: Dict) -> None:
+        for cb in self.callbacks:
+            cb.set_params(params)
+
+    def set_model(self, model: tf.keras.models.Model) -> None:
+        self.model = model
+        for cb in self.callbacks:
+            cb.set_model(model)
+
+    def on_epoch_begin(self, epoch: int, logs: Optional[Dict] = None) -> None:
+        # We'll call this explicitly when we want it, via _corrected_epoch_begin().
+        pass
+
+    def on_epoch_end(self, epoch: int, logs: Optional[Dict] = None) -> None:
+        # We'll call this explicitly when we want it, via _corrected_epoch_end().
+        pass
+
+    # Train-related callbacks.
+
+    def on_train_begin(self, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_train_begin(polylogs(supports_tf_logs))
+        # Now it is safe to load callback state.
+        self._delayed_load_state()
+
+    def on_train_batch_begin(self, _: int, logs: Optional[Dict] = None) -> None:
+        self._check_epoch_begin()
+        self._check_train_workload_begin()
+
+        assert isinstance(logs, dict)
+        if "batch" in logs:
+            logs["batch"] = self.state.epoch_batches
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_train_batch_begin(self.state.epoch_batches, polylogs(supports_tf_logs))
+
+    def on_train_batch_end(self, batch: int, logs: Optional[Dict] = None) -> None:
+        assert isinstance(logs, dict)
+        if "batch" in logs:
+            logs["batch"] = self.state.epoch_batches
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_train_batch_end(self.state.epoch_batches, polylogs(supports_tf_logs))
+
+        self.state.total_batches += 1
+        self.state.epoch_batches += 1
+
+        if (
+            self.batches_per_epoch is not None
+            and self.state.epoch_batches >= self.batches_per_epoch
+        ):
+            self._corrected_epoch_end(epoch=self.state.epoch, logs={})
+            self.state.epoch_batches = 0
+            self.state.epoch += 1
+            self.state.want_epoch_begin = True
+
+    def on_train_end(self, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_train_end(polylogs(supports_tf_logs))
+
+    # Test-related callbacks.
+
+    def on_test_begin(self, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_test_begin(polylogs(supports_tf_logs))
+
+    def on_test_batch_begin(self, batch: int, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_test_batch_begin(batch, polylogs(supports_tf_logs))
+
+    def on_test_batch_end(self, batch: int, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_test_batch_end(batch, polylogs(supports_tf_logs))
+
+    def on_test_end(self, logs: Optional[Dict] = None) -> None:
+        # Ignore on_test_end, since in TF 1.X it is called without metrics, and we want to
+        # guarantee the TF2.X behavior that logs contains useful logs.  Additionally, even in
+        # TF2.X these metrics would not yet be aggregated across GPUs.
+        pass
+
+    # Predict-related callbacks.
+
+    def on_predict_begin(self, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_predict_begin(polylogs(supports_tf_logs))
+
+    def on_predict_batch_begin(self, batch: int, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_predict_batch_begin(batch, polylogs(supports_tf_logs))
+
+    def on_predict_batch_end(self, batch: int, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_predict_batch_end(batch, polylogs(supports_tf_logs))
+
+    def on_predict_end(self, logs: Optional[Dict] = None) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_predict_end(polylogs(supports_tf_logs))
+
+    def _corrected_epoch_begin(self, epoch: int, logs: Dict) -> None:
+        """The real on_epoch_begin call, which is guaranteed to happen at the right time."""
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_epoch_begin(epoch, polylogs(supports_tf_logs))
+
+    def _corrected_epoch_end(self, epoch: int, logs: Dict) -> None:
+        """The real on_epoch_end call, which is guaranteed to happen at the right time."""
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_epoch_end(epoch, polylogs(supports_tf_logs))
+
+    def _corrected_test_end(self, logs: Dict) -> None:
+        polylogs = _PolyLogs(logs)
+        for cb in self.callbacks:
+            supports_tf_logs = getattr(cb, "_supports_tf_logs", False)
+            cb.on_test_end(polylogs(supports_tf_logs))
+
+    def _check_train_workload_begin(self) -> None:
+        if not self.want_train_workload_begin:
+            return
+        self.want_train_workload_begin = False
+        for cb in self.callbacks:
+            if isinstance(cb, Callback):
+                cb.on_train_workload_begin(self.state.total_batches, self.batches_requested, {})
+
+    def _check_epoch_begin(self) -> None:
+        if not self.state.want_epoch_begin:
+            return
+        self.state.want_epoch_begin = False
+        self._corrected_epoch_begin(self.state.epoch, {})
+
+    def _delayed_load_state(self) -> None:
+        """
+        Load state after on_train_begin, so that only the first on_train_begin can affect savable
+        state.  This is more consistent with how we don't allow on_train_end to alter savable
+        state, and also all TF-authored Callbacks would break if we didn't do it this way.
+        """
+        if self.load_state is None:
+            return
+        self.state = self.SavableState(**self.load_state["self"])
+        for cb, cb_state in zip(self.all_callbacks, self.load_state["callbacks"]):
+            if isinstance(cb, Callback):
+                cb.load_state(cb_state)
+
+    # Must be triggered externally.
+    def _get_state(self) -> Dict:
+        cb_state = [
+            cb.get_state() if isinstance(cb, Callback) else None for cb in self.all_callbacks
+        ]
+        return {"self": vars(self.state), "callbacks": cb_state}
+
+    # Must be triggered externally.
+    def _checkpoint_end(self, checkpoint_dir: str) -> None:
+        for cb in self.callbacks:
+            if isinstance(cb, Callback):
+                cb.on_checkpoint_end(checkpoint_dir)
+
+    # Must be triggered externally.
+    def set_batches_requested(self, batches_requested: int) -> None:
+        self.batches_requested = batches_requested
+
+    # Must be triggered externally.
+    def _test_end(self, logs: Dict) -> None:
+        self._corrected_test_end(logs)
+
+    # Must be triggered externally.
+    def _train_workload_end(self, metrics: Dict) -> None:
+        self.state.latest_training_metrics = metrics
+        for cb in self.callbacks:
+            if isinstance(cb, Callback):
+                cb.on_train_workload_end(self.state.total_batches, metrics)
+        self.want_train_workload_begin = True
+
+
+class DeterminedProgress(Callback):
+    """
+    A Determined-friendly replacement for the usual verbose=1 behavior.
+
+    To use it with a TFKerasTrial, simply pass it as one of the keras_callbacks:
+
+    .. code-block:: python
+
+       class MyTFKerasTrial(TFKerasTrial):
+           ...
+
+           def keras_callbacks(self):
+               return [DeterminedProgess()]
+    """
+
+    _chief_worker_only = True
+    _supports_tf_logs = True
+
+    class SavableState:
+        """SavableState makes it easy to persist state using vars(self.state)."""
+
+        def __init__(self, trained_total: int, validation_len: Optional[int]) -> None:
+            self.trained_total = trained_total
+            self.validation_len = validation_len
+
+    def __init__(self) -> None:
+        self.state = self.SavableState(trained_total=0, validation_len=None)
+        self.train_len = None  # type: Optional[int]
+        self.batches = 0
+        self.percent_reported = -1
+
+    def _report(
+        self, logs: Optional[Dict], training: bool, batches: int, total: Optional[int]
+    ) -> None:
+        # Only report progress if we have the target total.
+        if total is None:
+            return
+
+        # Don't report more often than 10% increments.
+        percent_10 = int((batches / total) * 10) * 10
+        if percent_10 <= self.percent_reported:
+            print(f"{percent_10} <= {self.percent_reported}")
+            return
+
+        # When you do report, report to 1% accuracy.
+        percent = int((batches / total) * 100)
+
+        if training:
+            report = (
+                f"total batches trained: {self.state.trained_total}, "
+                f"workload {percent}% complete ({batches}/{total})"
+            )
+        else:
+            report = (
+                f"validation after batch: {self.state.trained_total}, "
+                f"validation {percent}% complete ({batches}/{total})"
+            )
+        if logs is not None:
+            metrics = {k: v for k, v in logs.items() if k not in ("batch", "size")}
+            report += f": {metrics}"
+
+        print(report)
+
+    def on_train_workload_begin(
+        self, total_batches_trained: int, batches_requested: Optional[int], logs: Dict
+    ) -> None:
+        self.train_len = batches_requested
+        self.batches = 0
+        self.state.trained_total = total_batches_trained
+        self._report(logs=None, training=True, batches=self.batches, total=self.train_len)
+
+    def on_train_batch_end(self, batch: int, logs: Dict) -> None:
+        self.batches += 1
+        self.state.trained_total += 1
+        self._report(logs=logs, training=True, batches=self.batches, total=self.train_len)
+
+    def on_test_begin(self, logs: Dict) -> None:
+        self.batches = 0
+        self._report(logs=None, training=False, batches=0, total=self.state.validation_len)
+
+    def on_test_batch_end(self, batch: int, logs: Dict) -> None:
+        self.batches += 1
+        self._report(
+            logs=logs, training=False, batches=self.batches, total=self.state.validation_len
+        )
+
+    def on_test_end(self, logs: Dict) -> None:
+        self.state.validation_len = self.batches
+
+    def get_state(self) -> Any:
+        return vars(self.state)
+
+    def load_state(self, state: Any) -> None:
+        self.state = self.SavableState(**state)
+
+
+class _DeterminedHistory(Callback):
+    """Like tf.keras.callbacks.History but based on validations and stateful."""
+
+    def __init__(self) -> None:
+        self.history = {}  # type: Dict
+
+    def on_test_end(self, logs: Dict) -> None:
+        for k, v in logs.items():
+            self.history.setdefault(k, []).append(v)
+
+        # I'm not sure how this ever gets unset but keras definitely thinks it's possible.
+        self.model.history = self
+
+    def get_state(self) -> Any:
+        return self.history
+
+    def load_state(self, state: Any) -> None:
+        self.history = state
+
+
+def _tf_keras_callback_get_state(cb: Any) -> Any:
+    """Get state based on _savable_attributes."""
+    cb_name = type(cb).__name__
+    for var in vars(cb):
+        if var not in cb._savable_attributes and var not in cb._extra_attributes:
+            raise NotImplementedError(
+                f"The Determined {cb_name} is not known to work with an implementation of "
+                f"{cb_name} that contains a variable named {var}."
+            )
+        return {var: getattr(cb, var) for var in cb._savable_attributes if hasattr(cb, var)}
+
+
+def _tf_keras_callback_load_state(cb: Any, state: Any) -> None:
+    """Load state based on _savable_attributes."""
+    for var in cb._savable_attributes:
+        if var in state:
+            setattr(cb, var, state[var])
+
+
+class EarlyStopping(tf.keras.callbacks.EarlyStopping, Callback):  # type: ignore
+    """
+    EarlyStopping behaves exactly like the ``tf.keras.callbacks.EarlyStopping`` except that it
+    checks after every on_test_end() rather than every on_epoch_end() and it can save and restore
+    its state after pauses in training.
+
+    Therefore, part of configuring the Determined implementation of EarlyStopping is to
+    configure min_validation_period for the experiment appropriately (likely it should be
+    configured to validate every epoch).
+
+    In Determined, on_test_end may be called slightly more often that min_validation_period during
+    some types of hyperparameter searches, but it is unlikely for that to occur often enough have
+    a meaningful impact on this callback's operation.
+    """
+
+    _savable_attributes = {
+        # tf.keras.callbacks.EarlyStopping values.
+        "baseline",
+        "best_weights",
+        "restore_best_weights",
+        "stopped_epoch",
+        "wait",
+        # Our own values.
+        "test_end_count",
+    }
+
+    _extra_attributes = {
+        # Base Callback values.
+        "model",
+        "params",
+        "validation_data",
+        "_chief_worker_only",
+        "_supports_tf_logs",
+        # Constant config values.
+        "best",
+        "min_delta",
+        "monitor",
+        "monitor_op",
+        "patience",
+        "verbose",
+        # Our own values.
+        "_extra_attributes",
+        "_savable_attributes",
+    }
+
+    def __init__(self, *arg: Any, **kwarg: Any) -> None:
+        # We have a diamond inheritance pattern, so avoid calling super().
+        tf.keras.callbacks.EarlyStopping.__init__(self, *arg, **kwarg)
+        self.test_end_count = 0
+
+    def on_epoch_end(self, epoch: int, logs: Optional[Dict]) -> None:
+        # Ignore on_epoch_end calls, which never contain metrics in Determined.
+        pass
+
+    def on_test_end(self, logs: Optional[Dict] = None) -> None:
+        # Trigger the original EarlyStopping's on_epoch_end call.
+        tf.keras.callbacks.EarlyStopping.on_epoch_end(self, self.test_end_count, logs)
+        self.test_end_count += 1
+
+    def get_state(self) -> Any:
+        return _tf_keras_callback_get_state(self)
+
+    def load_state(self, state: Any) -> None:
+        _tf_keras_callback_load_state(self, state)
+
+
+class ReduceLROnPlateau(tf.keras.callbacks.ReduceLROnPlateau, Callback):  # type: ignore
+    """
+    ReduceLROnPlateau behaves exactly like the ``tf.keras.callbacks.ReduceLROnPlateau`` except that
+    it checks after every on_test_end() rather than every on_epoch_end() and it can save and
+    restore its state after pauses in training.
+
+    Therefore, part of configuring the Determined implementation of ReduceLROnPlateau is to
+    configure min_validation_period for the experiment appropriately (likely it should be
+    configured to validate every epoch).
+
+    In Determined, on_test_end may be called slightly more often that min_validation_period during
+    some types of hyperparameter searches, but it is unlikely for that to occur often enough have
+    a meaningful impact on this callback's operation.
+    """
+
+    _savable_attributes = {
+        # tf.keras.callbacks.ReduceLROnPlateau values.
+        "cooldown_counter",
+        "wait",
+        "best",
+        # Our own values.
+        "test_end_count",
+    }
+
+    _extra_attributes = {
+        # Base Callback values.
+        "model",
+        "params",
+        "validation_data",
+        "_chief_worker_only",
+        "_supports_tf_logs",
+        # Constant config values.
+        "cooldown",
+        "factor",
+        "min_delta",
+        "min_lr",
+        "mode",
+        "monitor",
+        "monitor_op",
+        "patience",
+        "verbose",
+        # Our own values.
+        "_extra_attributes",
+        "_savable_attributes",
+    }
+
+    def __init__(self, *arg: Any, **kwarg: Any) -> None:
+        # We have a diamond inheritance pattern, so avoid calling super().
+        tf.keras.callbacks.ReduceLROnPlateau.__init__(self, *arg, **kwarg)
+        self.test_end_count = 0
+
+    def on_epoch_end(self, epoch: int, logs: Optional[Dict]) -> None:
+        # Ignore on_epoch_end calls, which never contain metrics in Determined.
+        pass
+
+    def on_test_end(self, logs: Optional[Dict] = None) -> None:
+        # Trigger the original ReduceLROnPlateau's on_epoch_end call.
+        tf.keras.callbacks.ReduceLROnPlateau.on_epoch_end(self, self.test_end_count, logs)
+        self.test_end_count += 1
+
+    def get_state(self) -> Any:
+        return _tf_keras_callback_get_state(self)
+
+    def load_state(self, state: Any) -> None:
+        _tf_keras_callback_load_state(self, state)

--- a/harness/tests/experiment/fixtures/keras_cb_checker.py
+++ b/harness/tests/experiment/fixtures/keras_cb_checker.py
@@ -1,0 +1,250 @@
+import io
+from typing import Any, Callable, Dict, List, Optional, Set
+
+import determined as det
+import determined.keras
+
+train_begin = "on_train_begin"
+train_workload_begin = "on_train_workload_begin"
+train_batch_begin = "on_train_batch_begin"
+train_batch_end = "on_train_batch_end"
+train_workload_end = "on_train_workload_end"
+test_begin = "on_test_begin"
+test_batch_begin = "on_test_batch_begin"
+test_batch_end = "on_test_batch_end"
+test_end = "on_test_end"
+epoch_begin = "on_epoch_begin"
+epoch_end = "on_epoch_end"
+train_end = "on_train_end"
+get_state = "get_state"
+load_state = "load_state"
+
+all_checks = []
+
+
+def cb_check(fn: Callable) -> Callable:
+    all_checks.append(fn)
+    return fn
+
+
+def do_check_with_table(lines: List[str], transitions: Dict[str, Set[Optional[str]]]) -> None:
+    state = None
+    i_prev = None
+    for i, line in enumerate(lines):
+        cb = line.split(":")[0]
+        if cb in transitions:
+            assert (
+                state in transitions[cb]
+            ), f"illegal callback {cb} on line {i} after {state} on line {i_prev}"
+            state = cb
+            i_prev = i
+
+
+@cb_check
+def check_train_begin_and_end(lines: List[str], **kwargs: Dict) -> None:
+    assert lines[0].startswith(train_begin), "first call was not on_train_begin"
+    assert lines[-1].startswith(train_end), "last call was not on_train_end"
+
+
+@cb_check
+def check_pause_continues(lines: List[str], **kwargs: Dict) -> None:
+    do_check_with_table(
+        lines,
+        {
+            train_begin: {None},
+            load_state: {train_begin, get_state},
+            get_state: {train_begin, load_state, get_state},
+            train_end: {train_begin, load_state, get_state},
+        },
+    )
+
+
+@cb_check
+def check_initial_calls(lines: List[str], **kwargs: Dict) -> None:
+    """
+    Always expect the following commands before the first training
+      - on_epoch_begin
+      - on_train_workload_begin
+      - on_validation_period_begin
+
+    (except in the case of continued training, of course)
+    """
+    expect = {epoch_begin, train_workload_begin}
+    remain = {epoch_begin, train_workload_begin}
+
+    for i, line in enumerate(lines):
+        cb = line.split(":")[0]
+        if cb in expect:
+            assert cb in remain, f"got two {cb} on line {i}"
+            remain.remove(cb)
+        elif line.startswith("on_train_batch_begin"):
+            assert len(remain) == 0, f"still expecting {remain} on line {i}"
+            break
+
+
+@cb_check
+def check_train_callbacks(lines: List[str], **kwargs: Dict) -> None:
+    """
+    All test_{begin,end} calls should be wrapped within validation_period_{begin,end}.
+
+    (This assumes we only have validation_period-related model.evaluate() calls.)
+    """
+    do_check_with_table(
+        lines,
+        {
+            train_begin: {None},
+            train_workload_begin: {train_begin, train_workload_end},
+            train_batch_begin: {train_workload_begin, train_batch_end},
+            train_batch_end: {train_batch_begin},
+            train_workload_end: {train_batch_end},
+            train_end: {train_workload_end},
+        },
+    )
+
+
+@cb_check
+def check_test_callbacks(lines: List[str], **kwargs: Dict) -> None:
+    """
+    All test_{begin,end} calls should happen outside of train_workload_{begin,end} periods.
+    """
+    do_check_with_table(
+        lines,
+        {
+            train_begin: {None},
+            train_workload_begin: {train_begin, train_workload_end, test_end},
+            train_workload_end: {train_workload_begin},
+            test_begin: {train_begin, train_workload_end},
+            test_batch_begin: {test_begin, test_batch_end},
+            test_batch_end: {test_batch_begin},
+            test_end: {test_batch_end},
+            train_end: {test_end, train_workload_end},
+        },
+    )
+
+
+@cb_check
+def check_sane_epochs(lines: List[str], **kwargs: Dict) -> None:
+    do_check_with_table(
+        lines,
+        {
+            train_begin: {None},
+            epoch_begin: {train_begin, epoch_end},
+            epoch_end: {epoch_begin},
+        },
+    )
+
+
+@cb_check
+def check_validation_and_epoch_counts(lines: List[str], **kwargs: Dict) -> None:
+    """Ensure that validation_period and epoch indices increment by 1 each time."""
+    counts = {"on_epoch": 0, "on_validation_period": 0}
+    for i, line in enumerate(lines):
+        cb = line.split(":")[0]
+        for prefix in counts:
+            if cb.startswith(prefix):
+                cb_idx = int(line.split(":")[1])
+                if cb.endswith("begin"):
+                    "got on_validation_period_begin for index 0 but expected 0 on line {i}"
+                    assert (
+                        cb_idx == counts[prefix]
+                    ), f"got {cb} for index {cb_idx} but expected {counts[prefix]} on line {i}"
+                if cb.endswith("end"):
+                    assert (
+                        cb_idx == counts[prefix]
+                    ), f"got {cb} for index {cb_idx} but expected {counts[prefix]} on line {i}"
+                    counts[prefix] += 1
+
+
+@cb_check
+def check_epoch_ends(lines: List[str], **kwargs: Dict) -> None:
+    """Ensure the correct number of epochs were called"""
+    count = kwargs.get("epochs")
+    if not isinstance(count, int):
+        return
+    seen = 0
+    for i, line in enumerate(lines):
+        if line.startswith(epoch_end):
+            seen += 1
+            assert seen <= count, f"saw {epoch_end} {seen} on line {i} but expected only {count}"
+    assert seen == count, f"expected {count} {epoch_end} calls but only saw {seen}"
+
+
+@cb_check
+def check_test_ends(lines: List[str], **kwargs: Dict) -> None:
+    """Ensure the correct number of validation period ends were called"""
+    count = kwargs.get("validations")
+    if not isinstance(count, int):
+        return
+    seen = 0
+    for i, line in enumerate(lines):
+        if line.startswith(test_end):
+            seen += 1
+            assert seen <= count, f"saw {test_end} {seen} on line {i} but expected only {count}"
+    assert seen == count, f"expected {count} {test_end} calls but only saw {seen}"
+
+
+class CBChecker(det.keras.callbacks.Callback):
+    def __init__(self, epochs: Optional[int] = None, validations: Optional[int] = None) -> None:
+        super().__init__()
+        self.log = io.StringIO()
+        self.epochs = epochs
+        self.validations = validations
+
+    def on_train_begin(self, logs: Optional[Dict]) -> None:
+        print(f"{train_begin}:{logs}", file=self.log)
+
+    def on_train_end(self, logs: Optional[Dict]) -> None:
+        print(f"{train_end}:{logs}", file=self.log)
+
+        lines = self.log.getvalue().splitlines()
+
+        try:
+            for check in all_checks:
+                check(lines, epochs=self.epochs, validations=self.validations)
+        except AssertionError:
+            for i, line in enumerate(lines):
+                print(f"{i}:\t{line}")
+            raise
+
+    def on_test_begin(self, logs: Optional[Dict]) -> None:
+        print(f"{test_begin}:{logs}", file=self.log)
+
+    def on_test_end(self, logs: Optional[Dict]) -> None:
+        print(f"{test_end}:{logs}", file=self.log)
+
+    def on_epoch_begin(self, epoch: int, logs: Optional[Dict]) -> None:
+        print(f"{epoch_begin}:{epoch}:{logs}", file=self.log)
+
+    def on_epoch_end(self, epoch: int, logs: Optional[Dict]) -> None:
+        print(f"{epoch_end}:{epoch}:{logs}", file=self.log)
+
+    def on_train_batch_begin(self, batch: int, logs: Optional[Dict]) -> None:
+        print(f"{train_batch_begin}:{batch}:{logs}", file=self.log)
+
+    def on_train_batch_end(self, batch: int, logs: Optional[Dict]) -> None:
+        print(f"{train_batch_end}:{batch}:{logs}", file=self.log)
+
+    def on_test_batch_begin(self, batch: int, logs: Optional[Dict]) -> None:
+        print(f"{test_batch_begin}:{batch}:{logs}", file=self.log)
+
+    def on_test_batch_end(self, batch: int, logs: Optional[Dict]) -> None:
+        print(f"{test_batch_end}:{batch}:{logs}", file=self.log)
+
+    def on_train_workload_begin(
+        self, batches_trained: int, batches_requested: Optional[int], logs: Dict
+    ) -> None:
+        print(f"{train_workload_begin}:{batches_trained}:{batches_requested}:{logs}", file=self.log)
+
+    def on_train_workload_end(self, batches_trained: int, logs: Dict) -> None:
+        print(f"{train_workload_end}:{batches_trained}:{logs}", file=self.log)
+
+    def get_state(self) -> Any:
+        print(f"{get_state}:", file=self.log)
+        return self.log.getvalue()
+
+    def load_state(self, state: Any) -> None:
+        self.log = io.StringIO(state)
+        # Seek to the end of the StringI0.
+        pos, whence = 0, 2
+        self.log.seek(pos, whence)
+        print(f"{load_state}:", file=self.log)

--- a/harness/tests/experiment/fixtures/tf_keras_one_var_model.py
+++ b/harness/tests/experiment/fixtures/tf_keras_one_var_model.py
@@ -8,6 +8,7 @@ from tensorflow.keras.models import Sequential
 from tensorflow.keras.optimizers import SGD
 
 from determined import keras
+from tests.experiment.fixtures import keras_cb_checker
 
 
 def make_one_var_tf_dataset_loader(hparams: Dict[str, Any], batch_size: int):
@@ -66,3 +67,15 @@ class OneVarTrial(keras.TFKerasTrial):
     @staticmethod
     def calc_loss(w, values):
         return np.mean([(v - w * v) ** 2 for v in values])
+
+    def keras_callbacks(self):
+        epochs = self.context.get_hparams().get("epochs")
+        validations = self.context.get_hparams().get("validations")
+        # Include a bunch of callbacks just to make sure they work.
+        return [
+            keras_cb_checker.CBChecker(epochs=epochs, validations=validations),
+            keras.TFKerasTensorBoard(),
+            keras.callbacks.ReduceLROnPlateau(monitor="val_loss"),
+            keras.callbacks.EarlyStopping(restore_best_weights=True),
+        ]
+        return

--- a/harness/tests/experiment/fixtures/tf_keras_xor_model.py
+++ b/harness/tests/experiment/fixtures/tf_keras_xor_model.py
@@ -11,8 +11,8 @@ from determined import keras
 from tests.experiment.utils import make_xor_data_sequences, xor_data  # noqa: I202, I100
 
 
-class StopVeryEarlyCallback(tf.keras.callbacks.Callback):  # type: ignore
-    def on_epoch_end(self, _: int, logs: Any = None) -> None:
+class StopVeryEarlyCallback(keras.callbacks.Callback):  # type: ignore
+    def on_train_workload_end(self, _: int, logs: Any = None) -> None:
         self.model.stop_training = True
 
 


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking changes,
please include "BREAKING CHANGE:" at the beginning of your commit body.
At minimum, this section should include a bracketed reference to the Jira ticket,
e.g. "[DET-1234]". When squash-and-merging, copy this directly into the description field.
-->


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot as appropriate.
Reviewers may ask questions of this test plan to ensure adequate manual coverage of changes.
-->


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for particularly
tricky bits of code that could use extra scrutiny, historical context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->


## Checklist

- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
See [Release Note](../docs/release-notes/README.md) for details.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:
- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:
- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:
- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
